### PR TITLE
ushare.c: include config.h before checking for CONFIG_NLS

### DIFF
--- a/src/ushare.c
+++ b/src/ushare.c
@@ -56,11 +56,12 @@
 #include <upnp/upnp.h>
 #include <upnp/upnptools.h>
 
+#include "config.h"
+
 #if (defined(HAVE_SETLOCALE) && defined(CONFIG_NLS))
 # include <locale.h>
 #endif
 
-#include "config.h"
 #include "ushare.h"
 #include "services.h"
 #include "http.h"


### PR DESCRIPTION
When NLS support is enabled, we get following build errors:

```
  ushare.c: In function 'setup_i18n':
  ushare.c:745:3: warning: implicit declaration of function 'setlocale' [-Wimplicit-function-declaration]
     setlocale (LC_ALL, "");
     ^
  ushare.c:745:14: error: 'LC_ALL' undeclared (first use in this function)
     setlocale (LC_ALL, "");
                ^
  ushare.c:745:14: note: each undeclared identifier is reported only once for each function it appears in
  make[2]: *** [ushare.o] Error 1
```

When NLS support is enabled, configure script creates macro in config.h.
We check for CONFIG_NLS before including config.h which results in above
build errors as locale.h doesn't get included.

This patch fixes above build error by including config.h before we check for
CONFIG_NLS.

This build error is detected by Buildroot autobuilder
http://autobuild.buildroot.net/results/19d/19d67dd43e5a313c77e4be97ecb9811ffa52f797/

Signed-off-by: Rahul Bedarkar <rahul.bedarkar@imgtec.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/ushare/0003-ushare-c-include-config-h-before-checking-for-CONFIG-NLS.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>