### PR TITLE
src/services.c: fix SOAP action response

### DIFF
--- a/src/services.c
+++ b/src/services.c
@@ -113,6 +113,7 @@ upnp_add_response (struct action_event_t *event, char *key, const char *value)
   res = UpnpAddToActionResponse (&actionResult,
                                  UpnpActionRequest_get_ActionName_cstr(event->request),
                                  event->service->type, key, val);
+  UpnpActionRequest_set_ActionResult(event->request, actionResult);
 
   if (res != UPNP_E_SUCCESS)
     {


### PR DESCRIPTION
SOAP action response is broken since commit 4643b9cb9e6c0331fd663437a7ed8061b9edf971 which forgot to add a call to `UpnpActionRequest_set_ActionResult`

Fix #6

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>