### PR TITLE
src/ushare.h: fix display_headers declaration

### DIFF
--- a/src/ushare.h
+++ b/src/ushare.h
@@ -130,6 +130,6 @@ struct action_event_t {
   struct service_t *service;
 };
 
-inline void display_headers (void);
+void display_headers (void);
 
 #endif /* _USHARE_H_ */


### PR DESCRIPTION
Fix the following warning:

```
ushare.h:133:13: warning: inline function ‘display_headers’ declared but never defined
  133 | inline void display_headers (void);
      |             ^~~~~~~~~~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>