### PR TITLE
src/cds.c: fix strncpy warnings in matches_search

### DIFF
--- a/src/cds.c
+++ b/src/cds.c
@@ -591,7 +591,7 @@ matches_search (char *search_criteria, struct upnp_entry_t *entry)
                 strlen (SEARCH_CLASS_MATCH_KEYWORD)))
   {
     strncpy (keyword, search_criteria
-             + strlen (SEARCH_CLASS_MATCH_KEYWORD), sizeof (keyword));
+             + strlen (SEARCH_CLASS_MATCH_KEYWORD), sizeof (keyword) - 1);
     quote_closed = strchr (keyword, '"');
 
     if (quote_closed)
@@ -602,7 +602,7 @@ matches_search (char *search_criteria, struct upnp_entry_t *entry)
   {
     derived_from = true;
     strncpy (keyword, search_criteria
-             + strlen (SEARCH_CLASS_DERIVED_KEYWORD), sizeof (keyword));
+             + strlen (SEARCH_CLASS_DERIVED_KEYWORD), sizeof (keyword) - 1);
     quote_closed = strchr (keyword, '"');
 
     if (quote_closed)
@@ -613,7 +613,7 @@ matches_search (char *search_criteria, struct upnp_entry_t *entry)
   {
     protocol_contains = true;
     strncpy (keyword, search_criteria
-             + strlen (SEARCH_PROTOCOL_CONTAINS_KEYWORD), sizeof (keyword));
+             + strlen (SEARCH_PROTOCOL_CONTAINS_KEYWORD), sizeof (keyword) - 1);
     quote_closed = strchr (keyword, '"');
 
     if (quote_closed)


### PR DESCRIPTION
Fix the following warnings:

```
cds.c: In function ‘matches_search’:
cds.c:615:5: warning: ‘strncpy’ specified bound 256 equals destination size [-Wstringop-truncation]
  615 |     strncpy (keyword, search_criteria
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  616 |              + strlen (SEARCH_PROTOCOL_CONTAINS_KEYWORD), sizeof (keyword));
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cds.c:604:5: warning: ‘strncpy’ specified bound 256 equals destination size [-Wstringop-truncation]
  604 |     strncpy (keyword, search_criteria
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  605 |              + strlen (SEARCH_CLASS_DERIVED_KEYWORD), sizeof (keyword));
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cds.c:593:5: warning: ‘strncpy’ specified bound 256 equals destination size [-Wstringop-truncation]
  593 |     strncpy (keyword, search_criteria
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  594 |              + strlen (SEARCH_CLASS_MATCH_KEYWORD), sizeof (keyword));
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>