### PR TITLE
src/trace.h: fix start_log declaration

### DIFF
--- a/src/trace.h
+++ b/src/trace.h
@@ -29,7 +29,7 @@ typedef enum {
 
 void print_log (log_level level, const char *format, ...)
   __attribute__ ((format (printf, 2, 3)));
-inline void start_log (void);
+void start_log (void);
 
 /* log_info
  * Normal print, to replace printf


### PR DESCRIPTION
Fix the following warning:

```
In file included from http.c:42:
trace.h:32:13: warning: inline function ‘start_log’ declared but never defined
   32 | inline void start_log (void);
      |             ^~~~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>