### PR TITLE
src/ctrl_telnet.c: fix fallthrough magic comment

### DIFF
--- a/src/ctrl_telnet.c
+++ b/src/ctrl_telnet.c
@@ -761,7 +761,7 @@ ctrl_telnet_tokenize (char *raw, int *argc, char ***argv)
           has_backslash = 2; /* FULHACK */
           break;
         }
-        /* Else: fall through */
+        /* fall through */
       case ' ':
       case '"':
         if (has_backslash)


### PR DESCRIPTION
Fix the following warning:

```
ctrl_telnet.c: In function ‘ctrl_telnet_tokenize’:
ctrl_telnet.c:759:12: warning: this statement may fall through [-Wimplicit-fallthrough=]
  759 |         if (!has_backslash)
      |            ^
ctrl_telnet.c:765:7: note: here
  765 |       case ' ':
      |       ^~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>